### PR TITLE
Custom segmenter model

### DIFF
--- a/scope/timecourse/process_experiment.py
+++ b/scope/timecourse/process_experiment.py
@@ -47,14 +47,13 @@ def compress_main(argv=None):
     compress_pngs(**args.__dict__)
 
 
-def segment_images(experiment_root, segmenter_path, model_path=None, timepoints=None, image_types=['bf'], overwrite_existing=False):
+def segment_images(experiment_root, segmenter_path, model_path, timepoints=None, image_types=['bf'], overwrite_existing=False):
     """Segment image files from an experiment directory.
 
     Parameters:
         experiment_root: top-level experiment directory
         segmenter_path: path to segmentation tool executable
-        model_path: path to the desired model; this can be an absolute path or a
-            relative path of the form 'models/(MODEL).mat' 
+        model_path: path to the desired model 
         timepoints: list of timepoints to compress (or list of glob expressions
             to match multiple timepoints). If None, compress all.
         segmenter_args: arguments, if any, to segmenter. The executable will be
@@ -71,8 +70,6 @@ def segment_images(experiment_root, segmenter_path, model_path=None, timepoints=
 
     Returns: return code of segmenter executable
     """
-    if model_path is None:
-        model_path = pkg_resources.resource_filename('worm_segmenter', 'models/default_CF.mat')
 
     experiment_root = pathlib.Path(experiment_root)
     mask_root = experiment_root / 'derived_data' / 'mask'

--- a/scope/timecourse/timecourse_handler.py
+++ b/scope/timecourse/timecourse_handler.py
@@ -5,6 +5,7 @@ import logging
 import time
 import datetime
 import pathlib
+import pkg_resources
 
 from . import base_handler
 from . import process_experiment
@@ -85,6 +86,7 @@ class BasicAcquisitionHandler(base_handler.TimepointHandler):
     IL_FIELD_WHEEL = None # 'circle:3' is a good choice.
     VIGNETTE_PERCENT = 5 # 5 is a good number when using a 1x optocoupler. If 0.7x, use 35.
     SEGMENTATION_EXECUTABLE = None # path to image-segmentation executable to run in the background after the job ends.
+    MODEL_TO_USE = None # path to segmentation model used by the executable
     TO_SEGMENT = ['bf'] # image name or names to segment
 
     def configure_additional_acquisition_steps(self):
@@ -409,7 +411,6 @@ class BasicAcquisitionHandler(base_handler.TimepointHandler):
             # next time...
             lock = scope_configuration.CONFIG_DIR / 'segment_job'
             process_experiment.run_in_background(process_experiment.segment_images,
-                experiment_root=self.data_dir, segmenter_path=self.SEGMENTATION_EXECUTABLE,
+                experiment_root=self.data_dir, segmenter_path=self.SEGMENTATION_EXECUTABLE, model_path=self.MODEL_TO_USE,
                 image_types=self.TO_SEGMENT, overwrite_existing=False, nice=20,
                 delete_logfile=False, logfile=self.data_dir / 'segment.log', lock=lock)
-

--- a/scope/timecourse/timecourse_handler.py
+++ b/scope/timecourse/timecourse_handler.py
@@ -409,6 +409,9 @@ class BasicAcquisitionHandler(base_handler.TimepointHandler):
             # make sure everything gets segmented. Thus, even if a background
             # segmentation job dies midway, the files will get picked up the
             # next time...
+            if self.MODEL_TO_USE is None:
+                raise ValueError('MODEL_TO_USE cannot be None when performing segmentation')
+
             lock = scope_configuration.CONFIG_DIR / 'segment_job'
             process_experiment.run_in_background(process_experiment.segment_images,
                 experiment_root=self.data_dir, segmenter_path=self.SEGMENTATION_EXECUTABLE, model_path=self.MODEL_TO_USE,


### PR DESCRIPTION
These changes allow a user to run the segmenter using a custom segmentation model. These features have also been exposed in the timecourse_handler as appropriate. 

Since we haven't formally decided on how to roll out worm_segmenter, I've kept things as minimally connected as possible. Nothing *explicitly* depends on worm_segmenter being around (though, for instance, pkg_resources is preemptively imported for the user who wants to use the segmenter in their timecourse acquisition).