### PR TITLE
Reinit stage back to good state safely 

### DIFF
--- a/scope/device/leica/stage.py
+++ b/scope/device/leica/stage.py
@@ -318,12 +318,12 @@ class Stage(stand.LeicaComponent):
 
     def reset_x_high_soft_limit(self):
         self.send_message(
-            SET_X2_LIMIT, -1, async=False, 
+            SET_X2_LIMIT, -1, async=False,
             intent="reset x soft max to maximum allowed value by sending SET_X2_LIMIT with the special argument value -1.")
 
     def reset_y_high_soft_limit(self):
         self.send_message(
-            SET_Y2_LIMIT, -1, async=False, 
+            SET_Y2_LIMIT, -1, async=False,
             intent="reset y soft max to maximum allowed value by sending SET_Y2_LIMIT with the special argument value -1.")
 
     def reset_z_high_soft_limit(self):
@@ -472,6 +472,7 @@ class Stage(stand.LeicaComponent):
     def reinit_z(self):
         """Reinitialize z axis to correct for drift or "stuck" stage. Executes synchronously."""
         self.send_message(INIT_RANGE_Z, async=False, intent="init stage z axis")
+        self.z -= 5
 
     def set_xy_fine_control(self, fine):
         self.send_message(SET_XY_STEP_MODE, int(not fine), async=False)
@@ -715,4 +716,3 @@ def _calibrate_z_speed_coefficients(times, distances, speeds, ramps):
     Z_RAMP_MM_PER_SECOND_PER_SECOND_PER_UNIT *= ramp_factor
     Z_MOVE_FUDGE_FACTOR = fudge_factor
     return time_estimates
-

--- a/scope/timecourse/create_timecourse_dir.py
+++ b/scope/timecourse/create_timecourse_dir.py
@@ -168,12 +168,18 @@ def _choose_bf_metering_pos(positions):
     distance_sums = distances[:,:8].sum(axis=1)
     return pos_names[distance_sums.argmin()]
 
+def safe_reinit(scope):
+    old_x, old_y, old_z = scope.stage.position
+    scope.stage.reinit()
+    scope.stage.z = 15
+    scope.stage.x, scope.stage.y = old_x, old_y
+    scope.stage.z = min(0.95*scope.stage.z_high_soft_limit, old_z)
 
 def simple_get_positions(scope):
     """Return a list of interactively-obtained scope stage positions."""
     reinit = input('press enter when ready to reinit stage (or press n and enter to skip reinit) ')
     if reinit.lower() != 'n':
-        scope.stage.reinit()
+        safe_reinit(scope)
     positions = []
     print('Press enter after each position has been found; press control-c to end')
     while True:
@@ -210,7 +216,7 @@ def get_positions_with_roi(scope):
     """
     reinit = input('press enter when ready to reinit stage (or press n and enter to skip reinit) ')
     if reinit.lower() != 'n':
-        scope.stage.reinit()
+        safe_reinit(scope)
     viewer = scope_viewer_widget.ScopeViewerWidget(scope)
     viewer.show()
     focus_roi = roi.EllipseROI(viewer, geometry=((400, 200), (2200, 2000)))

--- a/scope/timecourse/create_timecourse_dir.py
+++ b/scope/timecourse/create_timecourse_dir.py
@@ -171,9 +171,8 @@ def _choose_bf_metering_pos(positions):
 def safe_reinit(scope):
     old_x, old_y, old_z = scope.stage.position
     scope.stage.reinit()
-    scope.stage.z = 15
+    scope.stage.z = 20
     scope.stage.x, scope.stage.y = old_x, old_y
-    scope.stage.z = min(0.95*scope.stage.z_high_soft_limit, old_z)
 
 def simple_get_positions(scope):
     """Return a list of interactively-obtained scope stage positions."""

--- a/scope/timecourse/create_timecourse_dir.py
+++ b/scope/timecourse/create_timecourse_dir.py
@@ -168,17 +168,14 @@ def _choose_bf_metering_pos(positions):
     distance_sums = distances[:,:8].sum(axis=1)
     return pos_names[distance_sums.argmin()]
 
-def safe_reinit(scope):
-    old_x, old_y, old_z = scope.stage.position
-    scope.stage.reinit()
-    scope.stage.z = 20
-    scope.stage.x, scope.stage.y = old_x, old_y
-
 def simple_get_positions(scope):
     """Return a list of interactively-obtained scope stage positions."""
     reinit = input('press enter when ready to reinit stage (or press n and enter to skip reinit) ')
     if reinit.lower() != 'n':
-        safe_reinit(scope)
+        old_x, old_y, old_z = scope.stage.position
+        scope.stage.reinit()
+        scope.stage.x, scope.stage.y = old_x, old_y
+
     positions = []
     print('Press enter after each position has been found; press control-c to end')
     while True:
@@ -215,7 +212,9 @@ def get_positions_with_roi(scope):
     """
     reinit = input('press enter when ready to reinit stage (or press n and enter to skip reinit) ')
     if reinit.lower() != 'n':
-        safe_reinit(scope)
+        old_x, old_y, old_z = scope.stage.position
+        scope.stage.reinit()
+        scope.stage.x, scope.stage.y = old_x, old_y
     viewer = scope_viewer_widget.ScopeViewerWidget(scope)
     viewer.show()
     focus_roi = roi.EllipseROI(viewer, geometry=((400, 200), (2200, 2000)))


### PR DESCRIPTION
During a stage reinit (e.g. prior to getting positions), the standard stage reinit leaves the scope (0,0,z_max~>25 mm). Thus, the stage position is left in a precarious state when one tries to go back to the original corral of interest, and this situation has led to problems previously (e.g. the last time we got PDMS on the 10X objective...). This pull request institutes a safe reinit that backs off after reinit'ing to a safe z position. These modifications also bring the stage back to its original position prior to reinit'ing.