### PR TITLE
Proposed fix to allow inverted scope acquisitions

### DIFF
--- a/scope/client_util/calibrate.py
+++ b/scope/client_util/calibrate.py
@@ -31,8 +31,9 @@ class DarkCurrentCorrector:
         self.exposure_times = []
         with contextlib.ExitStack() as stack:
             # set up all the scope states
-            stack.enter_context(scope.il.in_state(shutter_open=False))
-            stack.enter_context(scope.tl.in_state(shutter_open=False))
+            if hasattr(scope.il, 'shutter_open'):    # Inverted scope doesn't have shutters.
+                stack.enter_context(scope.il.in_state(shutter_open=False))
+                stack.enter_context(scope.tl.in_state(shutter_open=False))
             stack.enter_context(scope.tl.lamp.in_state(enabled=False))
             if hasattr(scope.il, 'spectra'):
                 stack.enter_context(scope.il.spectra.in_state(**{lamp+'_enabled': False for lamp in scope.il.spectra.lamp_specs.keys()}))

--- a/scope/timecourse/timecourse_handler.py
+++ b/scope/timecourse/timecourse_handler.py
@@ -153,17 +153,20 @@ class BasicAcquisitionHandler(base_handler.TimepointHandler):
             pass
         assert self.scope.nosepiece.magnification == objective
 
-        self.scope.il.shutter_open = True
         self.scope.il.spectra.lamps(**{lamp+'_enabled': False for lamp in self.scope.il.spectra.lamp_specs})
-        self.scope.tl.shutter_open = True
         self.scope.tl.lamp.enabled = False
-        self.scope.tl.condenser_retracted = objective == 5 # only retract condenser for 5x objective
-        if self.TL_FIELD_DIAPHRAGM is not None:
-            self.scope.tl.field_diaphragm = self.TL_FIELD_DIAPHRAGM
-        if self.TL_APERTURE_DIAPHRAGM is not None:
-            self.scope.tl.aperture_diaphragm = self.TL_APERTURE_DIAPHRAGM
-        if self.IL_FIELD_WHEEL is not None:
-            self.scope.il.field_wheel = self.IL_FIELD_WHEEL
+
+        if hasattr(self.scope.il, 'shutter_open'): # For non-inverted scope acquisitions
+            self.scope.il.shutter_open = True
+            self.scope.tl.shutter_open = True
+            self.scope.tl.condenser_retracted = objective == 5 # only retract condenser for 5x objective
+            if self.TL_FIELD_DIAPHRAGM is not None:
+                self.scope.tl.field_diaphragm = self.TL_FIELD_DIAPHRAGM
+            if self.TL_APERTURE_DIAPHRAGM is not None:
+                self.scope.tl.aperture_diaphragm = self.TL_APERTURE_DIAPHRAGM
+            if self.IL_FIELD_WHEEL is not None:
+                self.scope.il.field_wheel = self.IL_FIELD_WHEEL
+
         self.scope.il.filter_cube = self.experiment_metadata['filter_cube']
         self.scope.camera.sensor_gain = '16-bit (low noise & high well capacity)'
         self.scope.camera.readout_rate = self.PIXEL_READOUT_RATE


### PR DESCRIPTION
This is a combined bug report + fix addressing rpc-scope guide acquisitions on the inverted microscope. When attempting acquisitions, the code available on iscope (commit unknown; not switched to external pysrc yet) suffers from the following errors:

>2018-12-12 14:10:35    ERROR   .       Exception in timepoint:
Traceback (most recent call last):
  File "/usr/local/miniconda3/lib/python3.6/site-packages/scope/timecourse/base_handler.py", line 114, in run_timepoint
    self.configure_timepoint()
  File "/usr/local/miniconda3/lib/python3.6/site-packages/scope/timecourse/timecourse_handler.py", line 152, in configure_timepoint
    self.scope.il.shutter_open = True
  File "/usr/local/miniconda3/lib/python3.6/site-packages/scope/simple_rpc/rpc_client.py", line 147, in __setattr__
    raise RPCError('Attribute "{}" is not known, so its state cannot be communicated to the server.'.format(name))

(and on the appropriate fix,)

>2018-12-12 15:42:31    ERROR   .       Exception in timepoint:
Traceback (most recent call last):
  File "/usr/local/miniconda3/lib/python3.6/site-packages/scope/timecourse/base_handler.py", line 114, in run_timepoint
    self.configure_timepoint()
  File "/usr/local/miniconda3/lib/python3.6/site-packages/scope/timecourse/timecourse_handler.py", line 177, in configure_timepoint
    self.configure_calibrations() # sets self.bf_exposure and self.tl_intensity
  File "/usr/local/miniconda3/lib/python3.6/site-packages/scope/timecourse/timecourse_handler.py", line 206, in configure_calibrations
    self.dark_corrector = calibrate.DarkCurrentCorrector(self.scope)
  File "/usr/local/miniconda3/lib/python3.6/site-packages/scope/client_util/calibrate.py", line 34, in __init__
    stack.enter_context(scope.il.in_state(shutter_open=False))
  File "/usr/local/miniconda3/lib/python3.6/contextlib.py", line 330, in enter_context
    result = _cm_type.__enter__(cm)
  File "/usr/local/miniconda3/lib/python3.6/contextlib.py", line 81, in __enter__
    return next(self.gen)
  File "/usr/local/miniconda3/lib/python3.6/site-packages/scope/util/state_stack.py", line 60, in in_state
    self.push_state(**state)
  File "<string>", line 10, in push_state
  File "/usr/local/miniconda3/lib/python3.6/site-packages/scope/simple_rpc/rpc_client.py", line 36, in __call__
    raise RPCError(retval)
scope.simple_rpc.rpc_client.RPCError: Traceback (most recent call last):
  File "/usr/local/miniconda3/lib/python3.6/site-packages/scope/simple_rpc/rpc_server.py", line 43, in call
    response = self.run_command(py_command, args, kwargs)
  File "/usr/local/miniconda3/lib/python3.6/site-packages/scope/simple_rpc/rpc_server.py", line 232, in run_command
    return py_command(*args, **kwargs)
  File "/usr/local/miniconda3/lib/python3.6/site-packages/scope/device/leica/stand.py", line 96, in push_state
    super().push_state(**state)
  File "/usr/local/miniconda3/lib/python3.6/site-packages/scope/util/state_stack.py", line 39, in push_state
    old_state = {p:getattr(self, 'get_'+p)() for p, v in state.items()}
  File "/usr/local/miniconda3/lib/python3.6/site-packages/scope/util/state_stack.py", line 39, in <dictcomp>
    old_state = {p:getattr(self, 'get_'+p)() for p, v in state.items()}
AttributeError: 'IL' object has no attribute 'get_shutter_open'

Both of these errors arise from the unique inverted scope configuration (i.e. not having shutters, etc.). These problem spots are preserved up to the current rpc-scope master. This fix patches these issues.
